### PR TITLE
layout:cssButtons/sep-scroll

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -7,38 +7,31 @@ import { useNavigate } from 'react-router-dom';
 import { useThrottle } from '../../hooks/useThrottle';
 import { HeaderSearchIcon } from '../../assets/svgs';
 import { SearchState } from '../../store/search';
+import { useHandleScroll } from '../../hooks/useHandleScroll';
+import { useCallback } from 'react';
 
-const Header = () => {
+const Header = (props) => {
   const navigate = useNavigate();
+  const {hide, setHide} = props;
+  const [pageY, setPageY] = useState(0);
+  const documentRef = useRef(document);
+  const handleScroll = useCallback((event) => useHandleScroll(event, {setHide, setPageY, pageY}), [pageY, setHide]);
   const throttleScroll = useThrottle(handleScroll, 200);
 
-  // scrolls
-  const [hide, setHide] = useState(false);
-  const [pageY, setPageY] = useState(0);
   const [isSearchOpen, setIsSearchOpen] = useRecoilState(SearchState);
-  // console.log(pageY);
 
-  const documentRef = useRef(document);
-
-  function handleScroll(event) {
-    event.stopPropagation();
-    const { pageYOffset } = window;
-    const deltaY = pageYOffset - pageY;
-    const hide = pageYOffset !== 0 && deltaY >= 0;
-    setHide(hide);
-    setPageY(pageYOffset);
-  }
 
   const handleClickSearchToggle = (event) => {
-    setIsSearchOpen((currnt) => !currnt);
+    setIsSearchOpen((current) => !current);
   };
+  
   useEffect(() => {
     documentRef.current.addEventListener('scroll', throttleScroll);
     return () => documentRef.current.removeEventListener('scroll', throttleScroll);
-  }, [pageY]);
+  }, [handleScroll, throttleScroll]);
 
   return (
-    <header className='header'>
+    <header className={hide ? 'hide header': 'header'}>
       <h1 className='logo'>
         <span
           onClick={() => {

--- a/src/components/Header/TopButton.jsx
+++ b/src/components/Header/TopButton.jsx
@@ -2,16 +2,17 @@ import React from 'react';
 import './topButton.scss';
 import { MoveToTopIcon } from '../../assets/svgs/index';
 
-const TopButton = () => {
+const TopButton = (props) => {
   const moveToTop = () =>
     document.documentElement.scrollIntoView({
       behavior: 'smooth',
       block: 'start',
       inline: 'center',
     });
+  const {hide, setHide} = props;
 
   return (
-    <div className='top-button'>
+    <div className={hide ? 'hide top-button': 'top-button'}>
       <button className='top-btn' onClick={moveToTop}>
         <MoveToTopIcon />
       </button>

--- a/src/components/Header/topButton.scss
+++ b/src/components/Header/topButton.scss
@@ -1,16 +1,33 @@
-.top-button {
+@import '../../styles/mixins/responsive';
 
+.top-button {
   position: fixed;
-  z-index: 99;
+  z-index: 30;
+
+  @media only screen and (min-width: getMinBreakpoint(SD)) {
+    margin: 3rem;
+  }
+  @media only screen and (max-width: getMaxBreakpoint(SD)) {
+    transition: 0.4s ease;
+    &.hide {
+      transform: translateY(80px);
+      visibility: hidden;
+    }
+  }
+
+
+
 }
 
 .top-btn {
   position: fixed;
   bottom: 0;
   right: 0;
-  z-index: 99;
+  z-index: 30;
+  transition: 0.4s ease;
 
   @media only screen and (min-width: getMinBreakpoint(SD)) {
     margin: 3rem;
   }
+
 }

--- a/src/hooks/useHandleScroll.js
+++ b/src/hooks/useHandleScroll.js
@@ -1,0 +1,13 @@
+export function useHandleScroll(event, props) {
+  event.stopPropagation();
+  const { setHide, setPageY, pageY } = props;
+  const changeHide = (hide) => {
+    return setHide(hide);
+  };
+  const { pageYOffset } = window;
+  const deltaY = pageYOffset - pageY;
+  const hide = pageYOffset !== 0 && deltaY >= 0;
+  changeHide(hide);
+  setPageY(pageYOffset);
+  return pageY;
+}

--- a/src/routes/Layout/Layout.jsx
+++ b/src/routes/Layout/Layout.jsx
@@ -3,10 +3,11 @@ import { Outlet } from 'react-router-dom';
 import Header from '../../components/Header/Header';
 import TopButton from '../../components/Header/TopButton';
 const Layout = () => {
+  const [hide, setHide] = React.useState(false);
   return (
     <div>
-      <Header />
-      <TopButton />
+      <Header hide={hide} setHide={setHide} />
+      <TopButton hide={hide} setHide={setHide} />
       <main>
         <div className='inner'>
           <Outlet />

--- a/src/store/search.js
+++ b/src/store/search.js
@@ -22,4 +22,5 @@ export const dropdownState = atom({
 
 export const SearchState = atom({
   key: 'isSearchOpen',
+  default: false,
 });


### PR DESCRIPTION
## 작업내역
- handleScroll function 분리
- setHide 헤더가 아닌 레이아웃에서 관리하는 state로 변경
- 2를 이용하여 모바일에서는(타블렛, 데스크탑은 보임) 스크롤시 moveToTop 버튼 숨김
- 현재까지 반응형 적용 덜된 목록 (모달, 모달내 즐겨찾기 버튼, 헤더 즐겨찾기, 헤더 서치바)
- 무비데이터 2개 있는건 컨플날수도 있을 것 같아 그대로 두었어여!

## 수정파일
Header.jsx
TopButton.jsx
TopButton.scss
Layout.jsx
search.js <-- 얘는 오류픽스용으로 디폴트스테이트만 추가했습니다 