### PR TITLE
fix: 즐겨찾기 페이지 중복 게시물 에러 해결

### DIFF
--- a/src/api/useGetMovie.js
+++ b/src/api/useGetMovie.js
@@ -9,3 +9,8 @@ export const useGetAllMovies = async () => {
     console.log(error);
   }
 };
+
+export const useGetFavoriteMovies = async () => {
+  const response = await axios.get(`${BASE_URL}?like=true`);
+  return response.data;
+};

--- a/src/components/Favorites/Favorites.jsx
+++ b/src/components/Favorites/Favorites.jsx
@@ -1,9 +1,11 @@
-import { useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { favoriteMoviesData } from '../../store/movies';
+import { useGetFavoriteMovies } from '../../api/useGetMovie';
 import Card from '../Movies/Card/Card';
 
 const Favorites = () => {
-  const favorites = useRecoilValue(favoriteMoviesData);
+  const [favorites, setFavorites] = useRecoilState(favoriteMoviesData);
+  useGetFavoriteMovies().then((result) => setFavorites(result));
 
   return (
     <>
@@ -11,7 +13,7 @@ const Favorites = () => {
         <div className='movies'>
           {!!favorites.length || <span className='no_favorite_list'>즐겨찾기 내역이 없습니다</span>}
           {favorites?.map((favor) => (
-            <Card key={favor.id} movie={favor} role='presentation' />
+            <Card key={favor.id} movie={favor} atom={favoriteMoviesData} role='presentation' />
           ))}
         </div>
       </div>

--- a/src/components/Movies/Card/Card.jsx
+++ b/src/components/Movies/Card/Card.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { useRecoilState } from 'recoil';
 import { useModal } from '../../Modal';
-import { moviesData } from '../../../store/movies';
 import { useUpdateFavorite } from '../../../api/useUpdateFavorite';
 import { replaceItemAtIndex } from '../../../util/replaceItemAtIndex';
 import ModalContent from '../ModalContent/ModalContent';
 import './card.scss';
 
-const Card = ({ movie }) => {
+const Card = ({ movie, atom }) => {
   const [openModal] = useModal();
-  const [movies, setMovies] = useRecoilState(moviesData);
+  const [movies, setMovies] = useRecoilState(atom);
 
   const openModalWithData = () =>
     openModal({

--- a/src/components/Movies/index.jsx
+++ b/src/components/Movies/index.jsx
@@ -45,10 +45,10 @@ const Movies = () => {
             movies?.map((movie, i) => {
               return i === movies?.length - 1 && !loading && !end ? (
                 <div key={movie.id} ref={setLastElement}>
-                  <Card movie={movie} role='presentation' />
+                  <Card movie={movie} atom={moviesData} role='presentation' />
                 </div>
               ) : (
-                <Card key={movie.id} movie={movie} role='presentation' />
+                <Card key={movie.id} movie={movie} atom={moviesData} role='presentation' />
               );
             })}
         </div>

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,9 +1,5 @@
-import React from 'react';
 import styles from './Routes.module.scss';
 import { Route, Routes } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
-import { useGetAllMovies } from '../api/useGetMovie';
-import { moviesData } from '../store/movies';
 
 import Layout from './Layout/Layout';
 import Home from '../pages/Home/Home';
@@ -11,14 +7,6 @@ import Favorites from '../pages/Favorites/Favorites';
 import NotFound from '../pages/NotFound404/NotFound';
 
 const App = () => {
-  const { data } = useGetAllMovies();
-  const setMovies = useSetRecoilState(moviesData);
-
-  React.useEffect(() => {
-    if (data === undefined || data === null) return;
-    setMovies(data);
-  }, [data]);
-
   return (
     <div className={styles.app}>
       <Routes>

--- a/src/store/movies.js
+++ b/src/store/movies.js
@@ -1,10 +1,14 @@
-import { atom, selector, selectorFamily } from 'recoil';
+import { atom, selectorFamily } from 'recoil';
 
 export const moviesData = atom({
   key: 'moviesData',
   default: [],
 });
 
+export const favoriteMoviesData = atom({
+  key: 'favoriteMoviesData',
+  default: [],
+});
 
 export const modalMovieData = selectorFamily({
   key: 'modalMovieData',
@@ -12,14 +16,6 @@ export const modalMovieData = selectorFamily({
     (id) =>
     ({ get }) =>
       get(moviesData).find((movie) => movie.id === id),
-});
-
-export const favoriteMoviesData = selector({
-  key: 'favoriteMoviesData',
-  get: ({ get }) => {
-    const movies = get(moviesData);
-    return movies.filter((movie) => movie.like);
-  },
 });
 
 export const sortData = atom({
@@ -35,5 +31,4 @@ export const pageData = atom({
 export const isFilterData = atom({
   key: 'isFilterData',
   default: true,
-
 });


### PR DESCRIPTION
- 전체 데이터에서 selector을 이용해 즐겨찾기 게시물을 가져오는 방식은 무한스크롤로 에러가 발생
- card에 atom을 인자로 전달해 해당 컴포넌트가 사용되는 페이지에서 필요한 데이터를 fetch할 수 있도록 수정