### PR TITLE
fix: modify movies.scss

### DIFF
--- a/src/components/Movies/movies.scss
+++ b/src/components/Movies/movies.scss
@@ -12,11 +12,10 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    align-items: center;
     gap: 0.25rem;
     min-height: 100vh;
     background-color: $BLACK;
-    & .no_favorite_list{
+    & .no_favorite_list {
       width: 100%;
       text-align: center;
       margin-top: -5.75rem;


### PR DESCRIPTION
## 작업 내용
즐겨찾기에서 목록이 한 줄일 경우 세로 중앙정렬 되어서
위에 여백이 들어갑니다.
align-items: center 삭제

movies.scss 
.movies align-items: center 삭제